### PR TITLE
fix: replaced .invalidateQueries to removeQueries

### DIFF
--- a/client/src/components/NavMenu.tsx
+++ b/client/src/components/NavMenu.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { Popover, Transition } from "@headlessui/react";
 import { Bars3Icon } from "@heroicons/react/20/solid";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { User } from "@/types/index";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -11,9 +11,12 @@ type NavMenuProps = {
 
 export default function NavMenu({ name }: NavMenuProps) {
     const queryClient = useQueryClient();
+    const navigate = useNavigate();
     const logout = () => {
         localStorage.removeItem("AUTH_TOKEN");
-        queryClient.invalidateQueries({ queryKey: ["user"] });
+        queryClient.removeQueries({ queryKey: ["user"] });
+        queryClient.removeQueries({ queryKey: ["projects"] });
+        navigate("/auth/login");
     };
     return (
         <Popover className="relative">


### PR DESCRIPTION
This error consisted of the fact that when the user logged out, the "user" query was invalidated, so when he wanted to log in again, the token was created but the session was not started. The solution was to remove the query user and not invalidate it. The project query was also removed